### PR TITLE
Allow dashes in activity-track-input

### DIFF
--- a/src/Dime/TimetrackerBundle/Parser/ActivityRelationParser.php
+++ b/src/Dime/TimetrackerBundle/Parser/ActivityRelationParser.php
@@ -21,7 +21,7 @@ class ActivityRelationParser extends AbstractParser
     public function run($input)
     {
         // customer - project - serive (@ / :)
-        if (preg_match_all('/([@:\/#])(\w+)/', $input, $this->matches)) {
+        if (preg_match_all('/([@:\/#])([\w-]+)/', $input, $this->matches)) {
             foreach ($this->matches[1] as $key => $token) {
                 switch ($token) {
                     case '@':


### PR DESCRIPTION
the customer short code is automatically changed to from test_tester to test-tester, to add a customer in the quick box, the regex must allow a dash.
